### PR TITLE
✨ 만료된 쿠폰 삭제 스케줄러 구현

### DIFF
--- a/src/main/kotlin/coupong/nbc/coupongwowdeal/CoupongWowdealApplication.kt
+++ b/src/main/kotlin/coupong/nbc/coupongwowdeal/CoupongWowdealApplication.kt
@@ -3,9 +3,11 @@ package coupong.nbc.coupongwowdeal
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 class CoupongWowdealApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/controller/v1/CouponController.kt
+++ b/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/controller/v1/CouponController.kt
@@ -5,6 +5,7 @@ import coupong.nbc.coupongwowdeal.domain.coupon.service.v1.CouponService
 import coupong.nbc.coupongwowdeal.infra.security.UserPrincipal
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -41,5 +42,10 @@ class CouponController(
     ): ResponseEntity<Unit> {
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
             .body(couponService.expireCoupon(couponId))
+    }
+
+    @Scheduled(cron = "0 * * * * *")
+    fun deleteExpiredCoupon() {
+        couponService.deleteExpiredCoupon()
     }
 }

--- a/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/dto/CouponResponse.kt
+++ b/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/dto/CouponResponse.kt
@@ -21,7 +21,7 @@ data class CouponResponse(
                 discountPrice = couponInfo.coupon.discountPrice,
                 issuedAt = couponInfo.issuedAt,
                 usedAt = couponInfo.usedAt!!,
-                expirationAt = couponInfo.expirationAt
+                expirationAt = couponInfo.coupon.expirationAt
             )
         }
     }

--- a/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/model/v1/Coupon.kt
+++ b/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/model/v1/Coupon.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import java.time.LocalDateTime
 
 @Entity
 class Coupon(
@@ -19,6 +20,9 @@ class Coupon(
 
     @Column
     var currentQuantity: Int,
+
+    @Column
+    val expirationAt: LocalDateTime,
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/model/v1/CouponUser.kt
+++ b/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/model/v1/CouponUser.kt
@@ -27,9 +27,6 @@ class CouponUser(
     val issuedAt: LocalDateTime,
 
     @Column
-    val expirationAt: LocalDateTime,
-
-    @Column
     var usedAt: LocalDateTime? = null,
 
     @Id

--- a/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/repository/v1/CouponQueryDslRepository.kt
+++ b/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/repository/v1/CouponQueryDslRepository.kt
@@ -1,9 +1,36 @@
 package coupong.nbc.coupongwowdeal.domain.coupon.repository.v1
 
-import coupong.nbc.coupongwowdeal.infra.querydsl.QueryDslConfig
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.jpa.JPAExpressions
+import com.querydsl.jpa.JPQLQuery
+import com.querydsl.jpa.impl.JPAQueryFactory
+import coupong.nbc.coupongwowdeal.domain.coupon.model.v1.QCoupon
+import coupong.nbc.coupongwowdeal.domain.coupon.model.v1.QCouponUser
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 class CouponQueryDslRepository(
-    private val queryDslConfig: QueryDslConfig
-)
+    private val queryFactory: JPAQueryFactory
+) {
+    private val coupon = QCoupon.coupon
+    private val couponUser = QCouponUser.couponUser
+
+    fun deleteExpiredCoupon() {
+        val expiredCouponIds = JPAExpressions
+            .select(coupon.id)
+            .from(coupon)
+            .where(coupon.expirationAt.before(LocalDateTime.now()))
+
+        queryFactory.delete(couponUser)
+            .where(deleteSearch(expiredCouponIds))
+            .execute()
+
+        queryFactory.delete(coupon)
+            .where(coupon.expirationAt.before(LocalDateTime.now()))
+            .execute()
+    }
+
+    private fun deleteSearch(ids: JPQLQuery<Long>): BooleanBuilder =
+        BooleanBuilder().and(couponUser.coupon.id.`in`(ids))
+}

--- a/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/repository/v1/CouponRepository.kt
+++ b/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/repository/v1/CouponRepository.kt
@@ -7,4 +7,5 @@ interface CouponRepository {
     fun couponUserDelete(couponId: Long)
     fun findCouponUserByCouponId(couponId: Long, userId: Long): CouponUser?
     fun couponDelete(couponId: Long)
+    fun deleteExpiredCoupon()
 }

--- a/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/repository/v1/CouponRepositoryImpl.kt
+++ b/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/repository/v1/CouponRepositoryImpl.kt
@@ -20,10 +20,14 @@ class CouponRepositoryImpl(
     }
 
     override fun couponUserDelete(couponId: Long) {
-        return couponUserJpaRepository.deleteByCouponId(couponId)
+        couponUserJpaRepository.deleteByCouponId(couponId)
     }
 
     override fun couponDelete(couponId: Long) {
-        return couponJpaRepository.deleteById(couponId)
+        couponJpaRepository.deleteById(couponId)
+    }
+
+    override fun deleteExpiredCoupon() {
+        couponQueryDslRepository.deleteExpiredCoupon()
     }
 }

--- a/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/service/v1/CouponService.kt
+++ b/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/service/v1/CouponService.kt
@@ -10,4 +10,5 @@ interface CouponService {
     fun issueCoupon(): CouponResponse
     fun useCoupon(couponId: Long, userPrincipal: UserPrincipal)
     fun expireCoupon(couponId: Long)
+    fun deleteExpiredCoupon()
 }

--- a/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/service/v1/CouponServiceImpl.kt
+++ b/src/main/kotlin/coupong/nbc/coupongwowdeal/domain/coupon/service/v1/CouponServiceImpl.kt
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class CouponServiceImpl(
     private val couponRepository: CouponRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
 ) : CouponService {
     override fun getCouponList(userPrincipal: UserPrincipal): List<CouponResponse> {
         val userId = userPrincipal.id
@@ -38,6 +38,7 @@ class CouponServiceImpl(
         val requestUser = (userRepository.findByIdOrNull(userId)
             ?: throw ModelNotFoundException("User", userId))
 
+        //TODO 만료시간 체크 로직 필요
         couponRepository.findCouponUserByCouponId(couponId, userId)
             ?.also { check(it.user.id == requestUser.id) { throw AccessDeniedException("no permission") } }
             ?.also { it.use() }
@@ -48,5 +49,10 @@ class CouponServiceImpl(
     override fun expireCoupon(couponId: Long) {
         couponRepository.couponUserDelete(couponId)
         couponRepository.couponDelete(couponId)
+    }
+
+    @Transactional
+    override fun deleteExpiredCoupon() {
+        couponRepository.deleteExpiredCoupon()
     }
 }


### PR DESCRIPTION
## 요약

만료된 쿠폰 삭제 스케줄러 구현

## 작업 사항

- 🏷️ expirationAt 컬럼 Couponuser -> Coupon 엔티티로 이동
- ✨ 만료된 쿠폰 삭제 스케줄러 구현
  - 매일 자정에 동작
 
## 리뷰 요청 사항(선택)

스케줄러는 매일 자정에 돌도록 설정했습니다.
그리고 만료된 쿠폰이 삭제 되지 않아도 서비스에 큰 문제가 없을 거라 생각되어 만약 스케줄로 실행 중 오류가 생기면 그냥 다음 스케줄 시행을 기다리도록 구현했습니다. 다른 방식이 좋을까요?

---

### 해결한 이슈

closes: #33 
