### PR TITLE
:heavy_plus_sign: 테스트 관련 의존성 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,8 @@ repositories {
 
 val jjwtVersion = "0.12.6"
 val queryDslVersion = "5.0.0"
+val kotestVersion = "5.8.1"
+val fixtureMonkeyVersion = "1.0.14"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
@@ -49,6 +51,11 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.security:spring-security-test")
+    testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+    testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
+    testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter-kotlin:$fixtureMonkeyVersion")
+
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 


### PR DESCRIPTION
## 요약

> 간단 요약

Kotest, Fixture monkey를 선정했고 Repository Test 또는 Service + DB 테스트가 주 목적이기에 Mockito는 설정하지 않았습니다. 

필요한 경우 Controller 테스트에서 필요한 서비스는 Test double로 작성하면 될 것 같습니다

#15 댓글에 조금 더 구체적으로 선정 이유 적어놨습니다

## 작업 사항

> PR에서 작업한 사항들을 적어주세요(이미지, 스크린샷등을 활용해도 좋아요)

Kotest, Fixture monkey 추가

## 리뷰 요청 사항(선택)

> 리뷰시 봐주었으면 하는 부분이 있다면 적어주세요

---

### 해결한 이슈

closes: #15
